### PR TITLE
Implement Filtering for the Borrowings List endpoint

### DIFF
--- a/borrowings/views.py
+++ b/borrowings/views.py
@@ -15,19 +15,27 @@ class BorrowingViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
 
     def get_queryset(self):
-        """Filter borrowings by user ID and active status."""
+        """Filter borrowings by user ID, admin and active status."""
         queryset = super().get_queryset()
         user = self.request.user
+        user_id = self.request.query_params.get("user_id")
         is_active = self.request.query_params.get("is_active")
 
+        # Check if the user is a regular user
+        if not user.is_staff:
+            return queryset.filter(user=user)
+
+        # Check for active status filtering
         if is_active is not None:
             if is_active.lower() == "true":
                 queryset = queryset.filter(actual_return_date=None)
             elif is_active.lower() == "false":
                 queryset = queryset.filter(actual_return_date__isnull=False)
 
-        if not user.is_staff:
-            return queryset.filter(user=user)
+        # Check if user_id is provided and the user is an admin user
+        if user.is_staff:
+            if user_id:
+                queryset = queryset.filter(user_id=user_id)
 
         return queryset
 

--- a/borrowings/views.py
+++ b/borrowings/views.py
@@ -17,17 +17,17 @@ class BorrowingViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         """Filter borrowings by user ID and active status."""
         queryset = super().get_queryset()
-        user_id = self.request.query_params.get("user_id")
+        user = self.request.user
         is_active = self.request.query_params.get("is_active")
-
-        if user_id is not None:
-            queryset = queryset.filter(user_id=user_id)
 
         if is_active is not None:
             if is_active.lower() == "true":
                 queryset = queryset.filter(actual_return_date=None)
             elif is_active.lower() == "false":
                 queryset = queryset.filter(actual_return_date__isnull=False)
+
+        if not user.is_staff:
+            return queryset.filter(user=user)
 
         return queryset
 

--- a/library_service/settings.py
+++ b/library_service/settings.py
@@ -144,8 +144,8 @@ REST_FRAMEWORK = {
 SIMPLE_JWT = {
     "AUTH_HEADER_NAME": "HTTP_AUTHORIZE",
     "AUTH_HEADER_TYPES": ("Bearer",),
-    "ACCESS_TOKEN_LIFETIME": timedelta(hours=1),
-    "REFRESH_TOKEN_LIFETIME": timedelta(days=1),
+    "ACCESS_TOKEN_LIFETIME": timedelta(hours=168),  # 1 week for testing
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=30),  # 1 month for testing
 }
 
 AUTH_USER_MODEL = "users.User"


### PR DESCRIPTION
Add filtering for the Borrowings List endpoint

- Make sure all non-admins can see only their borrowings
- Make sure borrowings are available only for authenticated users
- Add the `is_active` parameter for filtering by active borrowings (still not returned)
- Add the `user_id` parameter for admin users, so admin can see all users’ borrowings, if not specified, but if specified - only for concrete user
![chrome_05 11 24_1607](https://github.com/user-attachments/assets/8f13c6c5-790a-4d9a-b717-aa50dfccaddc)
![chrome_05 11 24_1611](https://github.com/user-attachments/assets/79e1d2c6-191f-4764-8357-ef72c489fc95)
![chrome_05 11 24_1610](https://github.com/user-attachments/assets/0fd9a662-03b2-4d49-aecb-4c2e0310dc0b)
![chrome_05 11 24_1609](https://github.com/user-attachments/assets/eba38978-d1a6-470f-84c9-eb415d661e04)
![image](https://github.com/user-attachments/assets/d6d7a05e-5b9f-42db-bfa0-b65225720022)